### PR TITLE
Modify Kernel_Test_VM workflow to have a build job and have the test job wait on it.

### DIFF
--- a/.github/workflows/driver_test_vm.yml
+++ b/.github/workflows/driver_test_vm.yml
@@ -6,16 +6,17 @@
 #
 # For documentation on the syntax of this file, see
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
 name: Kernel_Test_VM
 
 on: pull_request
 
 jobs:
-  test:
+  build:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: [windows, self-hosted, kernel_test_vm]
+    runs-on: windows-latest
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: ebpf-for-windows.sln
@@ -32,29 +33,69 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Install LLVM and Clang
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        curl -fsSL -o LLVM10.exe https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe
+        7z x LLVM10.exe -y -o"C:/Program Files/LLVM"
+        echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
     - name: Restore NuGet packages
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      shell: cmd
-      run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
-        nuget restore ${{env.SOLUTION_FILE_PATH}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
     - name: Create verifier project
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      shell: cmd
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
         cd external\ebpf-verifier
-        rmdir /s /q build
         mkdir build
         cmake -B build
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      shell: cmd
-      run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
-        msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload Build Output
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: Build x64 ${{ matrix.configurations }}
+        path: ${{ github.workspace }}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        retention-days: 5
+
+  run_tests:
+    strategy:
+      matrix:
+        configurations: [Debug, Release]
+    runs-on: [windows, ebpf_cicd_tests]
+    env:
+      # Configuration type to build.
+      BUILD_CONFIGURATION: ${{matrix.configurations}}
+
+      BUILD_PLATFORM: x64
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.workflow_run.head_branch }}
+
+    - name: Wait for build to succeed
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      id: wait-for-build
+      with:
+        timeoutSeconds: 900
+        intervalSeconds: 60
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: build (${{env.BUILD_CONFIGURATION}})
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - name: Download build artifact
+      uses: actions/download-artifact@v2.1.0
+      with:
+        name: Build x64 ${{ matrix.configurations }}
+        path: ${{ github.workspace }}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
 
     - name: Set up CI/CD Tests
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
@@ -70,6 +111,14 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
         ./cleanup_ebpf_cicd_tests.ps1
+
+    - name: Upload any crash dumps
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: Crash-Dumps-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
+        path: c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        retention-days: 5
 
     - name: Upload log files
       if: always()

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -80,7 +80,7 @@ releases of eBPF for Windows will eventually be production signed at some point 
 security hardening is completed.)
 
 For basic testing, the simplest way to install eBPF for Windows is into a Windows VM with test signing enabled.
-Follow the [VM Installation Instructions](vm-setup.md) to do so.
+Follow the [VM Installation Instructions](vm-setup.md) and [eBPF Installation Instructions](installEbpf.md) to do so.
 
 ## Using eBPF for Windows
 

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -1,0 +1,26 @@
+# Installing eBPF into a Test VM
+
+Follow [VM Installation Instructions](vm-setup.md) for one-time setup of a test VM.
+Once the one-time setup has been completed, the following steps will
+install or update the eBPF installation in the VM, from a machine that
+has already built the binaries for x64/Debug or x64/Release.
+
+## Method 1
+1. Deploy the binaries to `C:\Temp` in your VM, as follows:
+    a. If you built the binaries from inside the VM, then from your ebpf-for-windows directory in the VM, do `.\scripts\deploy-ebpf -l`.  Otherwise,
+    b. If you built the binaries on the host machine, then from your ebpf-for-windows directory on the host machine, start an admin Powershell on the host machine and do `.\scripts\deploy-ebpf`.
+
+2. From within the VM, install the binaries as follows:
+    1. Start an admin command shell (cmd.exe).
+    2. Do 'cd C:\temp'.
+    3. Do 'install-ebpf.bat'.
+
+## Method 2
+Copy the build output to the host of the test VM and run the following.
+1. Create a snapshot of the test VM named **baseline**.
+2. Store the VM administrator credential:
+   1) `Install-Module CredentialManager -force`
+   2) `New-StoredCredential -Target `**`TEST_VM`**` -Username <VM Administrator> -Password <VM Administrator account password> -Persist LocalMachine`
+3. Modify `vm_list.json` to specify the name of the test VM under `VMList`.
+4. `Set-ExecutionPolicy unrestricted -Force`
+8. `Setup_ebpf_cicd_tests.ps1`

--- a/docs/SelfHostedRunnerSetup.md
+++ b/docs/SelfHostedRunnerSetup.md
@@ -1,10 +1,9 @@
 # Setup instructions for self-hosted runners
 
 The CI/CD tests for `eBPF for Windows` requires installing kernel drivers, that are not supported in Github-hosted runners.
-That is why self-host runners are needed to run those tests. The `Kernel_Test_VM` Github workflow runs on self-host runners that uses Hyper-V VM to deploy
-the eBPF components and runs the CI/CD tests on it. Using a Hyper-V VM enables the Github workflow to start from a clean state every time the test runs
+That is why self-host runners are needed to run those tests. The `run_tests` job in `Kernel_Test_VM` Github workflow (`driver_test_vm.yml`) runs on self-host runners that uses Hyper-V VM to deploy the eBPF components and runs the CI/CD tests on it. Using a Hyper-V VM enables the Github workflow to start from a clean state every time the test runs
 by restoring the VM to a "baseline" snapshot.
-This document discusses the steps to set up such a selfhost-runner that can run workflow for CI/CD tests.
+This document discusses the steps to set up such a selfhosted actions-runner that can run workflow for CI/CD tests on a fork of the eBPF for Windows repo.
 
 1) Install Windows Server 2019 - build 17763.
    1) [Windows Server 2019 Azure VM](https://portal.azure.com/#create/Microsoft.WindowsServer2019Datacenter-ARM)
@@ -14,30 +13,17 @@ This document discusses the steps to set up such a selfhost-runner that can run 
    3) ```Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.281.1/actions-runner-win-x64-2.281.1.zip -OutFile actions-runner-win-x64-2.281.1.zip```
    4) ```if((Get-FileHash -Path actions-runner-win-x64-2.281.1.zip -Algorithm SHA256).Hash.ToUpper() -ne 'b8dccfef39c5d696443d98edd1ee57881075066bb62adef0a344fcb11bd19f1b'.ToUpper()){ throw 'Computed checksum did not match' }```
    5) ```Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/actions-runner-win-x64-2.281.1.zip", "$PWD")```
-3) Obtain an [authentication token](https://github.com/microsoft/ebpf-for-windows/settings/actions/runners/new). This requires administrator permissions in the project.
+3) Create a new selfhosted runner for the fork. This requires administrator permissions in the project. Go to the settings menu in Github UI, select `Actions`->`Runners` and click on the `New selfhosted-runner` button. This will generate a token for the selfhosted runner.
 4) Configure action runner as follows:
-   ```./config.cmd --url https://github.com/microsoft/ebpf-for-windows --labels 'kernel_test_vm' --token <action runner token> --runasservice --windowslogonaccount <account> --windowslogonpassword <password> ```
+   ```./config.cmd --url <fork URL> --labels 'ebpf_cicd_tests' --token <action runner token> --runasservice --windowslogonaccount <account> --windowslogonpassword <password> ```
+   For the `--url` parameter provide the URL to the fork for which seflhosted runner is being configured.
+   For the `--token` parameter provide the token obtained in step 3.
+   The value for `--labels` parameter (`ebpf_cicd_tests`) is same as the `runs-on` field in the `run_tests` job defined in `run_tests.yml`.
    The `--runasservice` parameter makes the action runner run as a Windows service. The runner service runs as
    `NetworkService` by default. However, the `Kernel_Test_VM` workflow performs operations on a test VM that requires
    administrator privilege. So, the credentials of an account with administrator privilege must be supplied in
    `windowslogonaccount` and `windowslogonpassword` parameters.
-5) Install the build tools as follows:
-   1) Install [Git for Windows 64-bit](https://git-scm.com/download/win).
-   2) Install [Visual Studio Build Tools 2019](https://aka.ms/vs/16/release/vs_buildtools.exe).
-   3) From the Visual Studio Installer GUI choose the following:
-      1) MSVC v142 - VS 2019 C++ x64/x86 build tools (Latest).
-      2) Windows 10 SDK. Choose the latest available version.
-      3) C++ CMake tools for Windows.
-      4) MSVC v142 - VS 2019 C++ x64/x86 Spectre Mitigated libs (Latest).
-   4) [Windows Driver Kit for Windows 10, version 2004](https://go.microsoft.com/fwlink/?linkid=2128854). The WDK
-     version is 10.0.19041.685. Care must be taken that the version of the Windows 10 SDK in step 5.3.2 matches the
-     WDK version. If the build fails with `error MSB8020: The build tools for WindowsKernelModeDriver10.0 cannot
-     be found` then perform the following mitigation steps:
-      1) Copy `c:\Program Files (x86)\Windows Kits\10\Vsix\VS2019\WDK.vsix` to a file with the extension set to `.zip` instead of `.vsix` and extract it.
-      2) Copy all files under `$MSBuild\Microsoft\*` to `c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Microsoft`.
-   5) Download [Nuget.exe](https://www.nuget.org/downloads). Do not copy the nuget.exe file in `Windows\System32` folder, as that causes issues
-   running the `nuget restore` command. Instead copy it in some other folder and make sure that the path to that folder is added to the PATH system environmental variable.
-6) [Set up a test VM](https://github.com/microsoft/ebpf-for-windows/blob/master/docs/vm-setup.md) and create a snapshot named **baseline**.
+6) Follow the instructions in the [VM Installation Instructions](vm-setup.md) document to create a test VM and perform one-time setup steps. Then create a snapshot named **baseline**.
 7) Store the VM administrator credential:
    1) `Install-Module CredentialManager -force`
    2) `New-StoredCredential -Target `**`TEST_VM`**` -Username <VM Administrator> -Password <VM Administrator account password> -Persist LocalMachine`

--- a/docs/vm-setup.md
+++ b/docs/vm-setup.md
@@ -26,21 +26,6 @@
     2. Do `bcdedit.exe -set TESTSIGNING ON`.
     3. Restart the VM so that the change will be applied.
 
-## Installing eBPF into a VM
-
-Once the one-time setup has been completed, the following steps will
-install or update the eBPF installation in the VM, from a machine that
-has already built the binaries for x64/Debug.
-
-1. Deploy the binaries to `C:\Temp` in your VM, as follows:
-    a. If you built the binaries from inside the VM, then from your ebpf-for-windows directory in the VM, do `.\scripts\deploy-ebpf -l`.  Otherwise,
-    b. If you built the binaries on the host machine, then from your ebpf-for-windows directory on the host machine, start an admin Powershell on the host machine and do `.\scripts\deploy-ebpf`.
-
-2. From within the VM, install the binaries as follows:
-    1. Start an admin command shell (cmd.exe).
-    2. Do 'cd C:\temp'.
-    3. Do 'install-ebpf.bat'.
-
 ## Debugging a VM
 
 To debug kernel-mode issues in the VM, see [Setting up a Connection to a Virtual Machine in Visual Studio](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/setting-up-a-connection-to-a-virtual-machine-in-visual-studio).


### PR DESCRIPTION
This PR modifies the driver_test_vm.yml WF to have two jobs. The first one does a build on github action runner. The second one runs the kernel CICD tests on selfhosted runner. This job uses `fountainhead/action-wait-for-check@v1.0.0` action to wait for the build job to complete first.