### PR TITLE
user mode test hook provider for the sample extension

### DIFF
--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -4916,3 +4916,75 @@ TEST_CASE("custom_maps_concurrent_insert_delete_and_query_preprocess", "[custom_
 {
     _test_custom_maps_concurrent_insert_delete_and_query(false);
 }
+
+TEST_CASE("multi_attach_sample_extension", "[sample_ext]")
+{
+    _test_helper_end_to_end test_helper;
+    test_helper.initialize();
+
+    // Create a multi-instance hook provider for the sample extension.
+    multi_instance_hook_t hook(EBPF_PROGRAM_TYPE_SAMPLE, EBPF_ATTACH_TYPE_SAMPLE);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
+    program_info_provider_t sample_program_info;
+    REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
+
+    // Native programs must be loaded from distinct binaries.
+    // Create a copy of the DLL for the second instance.
+    const char* file_name1 = "test_sample_ebpf_um.dll";
+    const char* file_name2 = "test_sample_ebpf_um_2.dll";
+    REQUIRE(CopyFileA(file_name1, file_name2, FALSE) != 0);
+
+    const char* error_message = nullptr;
+    bpf_object_ptr object1;
+    bpf_object_ptr object2;
+    fd_t program_fd1;
+    fd_t program_fd2;
+
+    int result =
+        ebpf_program_load(file_name1, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object1, &program_fd1, &error_message);
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+        error_message = nullptr;
+    }
+    REQUIRE(result == 0);
+
+    result =
+        ebpf_program_load(file_name2, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object2, &program_fd2, &error_message);
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        ebpf_free((void*)error_message);
+        error_message = nullptr;
+    }
+    REQUIRE(result == 0);
+
+    // Attach program 1 with attach_id 0.
+    REQUIRE(hook.attach(program_fd1, 0) == EBPF_SUCCESS);
+
+    // Attach program 2 with attach_id 1.
+    REQUIRE(hook.attach(program_fd2, 1) == EBPF_SUCCESS);
+
+    // Fire program at attach_id 0.
+    INITIALIZE_SAMPLE_CONTEXT;
+    uint32_t hook_result = 0;
+    REQUIRE(hook.fire(ctx, &hook_result, 0) == EBPF_SUCCESS);
+    REQUIRE(hook_result == 42);
+
+    // Fire program at attach_id 1.
+    hook_result = 0;
+    REQUIRE(hook.fire(ctx, &hook_result, 1) == EBPF_SUCCESS);
+    REQUIRE(hook_result == 42);
+
+    // Verify that an unoccupied attach_id fails.
+    REQUIRE(hook.fire(ctx, &hook_result, 2) == EBPF_EXTENSION_FAILED_TO_LOAD);
+
+    // Detach and close.
+    hook.detach(0);
+    hook.detach(1);
+
+    bpf_object__close(object1.release());
+    bpf_object__close(object2.release());
+
+    // Clean up the copy.
+    DeleteFileA(file_name2);
+}

--- a/tests/libs/util/hook_helper.h
+++ b/tests/libs/util/hook_helper.h
@@ -15,6 +15,10 @@
 #include "usersim/ex.h"
 #include "usersim/ke.h"
 
+#include <map>
+#include <mutex>
+#include <vector>
+
 // Prototype added as the libbpf headers cause conflicts with the execution context headers.
 int
 bpf_link__destroy(bpf_link* link);
@@ -63,90 +67,6 @@ typedef class _hook_helper
         return ebpf_program_attach_by_fd(program_fd, &_attach_type, attach_parameters, attach_parameters_size, link);
     }
 
-  private:
-    ebpf_attach_type_t _attach_type;
-} hook_helper_t;
-
-typedef class _single_instance_hook : public _hook_helper
-{
-  public:
-    _single_instance_hook(
-        ebpf_program_type_t program_type,
-        ebpf_attach_type_t attach_type,
-        bpf_link_type link_type = BPF_LINK_TYPE_UNSPEC)
-        : _hook_helper{attach_type}, client_binding_context(nullptr), client_data(nullptr),
-          client_dispatch_table(nullptr), link_object(nullptr), client_registration_instance(nullptr),
-          nmr_binding_handle(nullptr), nmr_provider_handle(nullptr)
-    {
-        attach_provider_data.header = EBPF_ATTACH_PROVIDER_DATA_HEADER;
-        attach_provider_data.supported_program_type = program_type;
-        attach_provider_data.bpf_attach_type = ebpf_get_bpf_attach_type(&attach_type);
-        this->attach_type = attach_type;
-        attach_provider_data.link_type = link_type;
-        module_id.Guid = attach_type;
-    }
-    ebpf_result_t
-    initialize()
-    {
-        NTSTATUS status = NmrRegisterProvider(&provider_characteristics, this, &nmr_provider_handle);
-        return (status == STATUS_SUCCESS) ? EBPF_SUCCESS : EBPF_FAILED;
-    }
-    ~_single_instance_hook()
-    {
-        // Best effort cleanup. Ignore errors.
-        if (link_object) {
-            (void)ebpf_link_detach(link_object);
-            (void)ebpf_link_close(link_object);
-        }
-        if (nmr_provider_handle != NULL) {
-            NTSTATUS status = NmrDeregisterProvider(nmr_provider_handle);
-            if (status == STATUS_PENDING) {
-                NmrWaitForProviderDeregisterComplete(nmr_provider_handle);
-            } else {
-                ebpf_assert(status == STATUS_SUCCESS);
-            }
-        }
-    }
-
-    uint32_t
-    attach(_In_ const bpf_program* program)
-    {
-        return ebpf_program_attach(program, &attach_type, nullptr, 0, &link_object);
-    }
-
-    uint32_t
-    attach(
-        _In_ const bpf_program* program,
-        _In_reads_bytes_(attach_parameters_size) void* attach_parameters,
-        size_t attach_parameters_size)
-    {
-        return ebpf_program_attach(program, &attach_type, attach_parameters, attach_parameters_size, &link_object);
-    }
-
-    void
-    detach()
-    {
-        if (link_object != nullptr) {
-            if (ebpf_link_detach(link_object) == EBPF_SUCCESS) {
-                throw std::runtime_error("ebpf_link_detach failed");
-            }
-            ebpf_link_close(link_object);
-            link_object = nullptr;
-        }
-    }
-
-    _Must_inspect_result_ ebpf_result_t
-    detach(
-        fd_t program_fd, _In_reads_bytes_(attach_parameter_size) void* attach_parameter, size_t attach_parameter_size)
-    {
-        ebpf_result_t result = ebpf_program_detach(program_fd, &attach_type, attach_parameter, attach_parameter_size);
-        if (result == EBPF_SUCCESS) {
-            ebpf_link_close(link_object);
-            link_object = nullptr;
-        }
-        return result;
-    }
-
     void
     detach_link(_Inout_ bpf_link* link)
     {
@@ -172,62 +92,225 @@ typedef class _single_instance_hook : public _hook_helper
         close_link(link);
     }
 
-    _Must_inspect_result_ ebpf_result_t
-    fire(_Inout_ void* context, _Out_ uint32_t* result)
-    {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
-        }
-        ebpf_result_t (*invoke_program)(_In_ const void* link, _Inout_ void* context, _Out_ uint32_t* result) =
-            reinterpret_cast<decltype(invoke_program)>(client_dispatch_table->function[0]);
+  private:
+    ebpf_attach_type_t _attach_type;
+} hook_helper_t;
 
-        return invoke_program(client_binding_context, context, result);
+/**
+ * @brief General-purpose NMR hook provider supporting N clients keyed by attach_id.
+ *        Manages the NMR provider lifecycle and client attach/detach.
+ *        Programs attach with a uint8_t attach_id (from attach parameters); if no
+ *        attach_id is provided, defaults to 0. The attach_id can be any value as
+ *        long as it is unique among currently attached clients.
+ */
+typedef class _hook_provider : public _hook_helper
+{
+  public:
+    _hook_provider(
+        ebpf_program_type_t program_type,
+        ebpf_attach_type_t attach_type,
+        bpf_link_type link_type = BPF_LINK_TYPE_UNSPEC,
+        uint32_t max_clients = UINT32_MAX)
+        : _hook_helper{attach_type}, nmr_provider_handle(nullptr), _max_clients(max_clients)
+    {
+        attach_provider_data.header = EBPF_ATTACH_PROVIDER_DATA_HEADER;
+        attach_provider_data.supported_program_type = program_type;
+        attach_provider_data.bpf_attach_type = ebpf_get_bpf_attach_type(&attach_type);
+        this->attach_type = attach_type;
+        attach_provider_data.link_type = link_type;
+        module_id.Guid = attach_type;
+    }
+
+    ~_hook_provider()
+    {
+        if (nmr_provider_handle != NULL) {
+            NTSTATUS status = NmrDeregisterProvider(nmr_provider_handle);
+            if (status == STATUS_PENDING) {
+                NmrWaitForProviderDeregisterComplete(nmr_provider_handle);
+            } else {
+                ebpf_assert(status == STATUS_SUCCESS);
+            }
+        }
+    }
+
+    ebpf_result_t
+    initialize()
+    {
+        NTSTATUS status = NmrRegisterProvider(&provider_characteristics, this, &nmr_provider_handle);
+        return (status == STATUS_SUCCESS) ? EBPF_SUCCESS : EBPF_FAILED;
     }
 
     _Must_inspect_result_ ebpf_result_t
-    batch_begin(size_t state_size, _Out_writes_(state_size) void* state)
+    attach(fd_t program_fd, uint8_t attach_id)
     {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
+        bpf_link* link = nullptr;
+        ebpf_result_t result =
+            ebpf_program_attach_by_fd(program_fd, &attach_type, &attach_id, sizeof(attach_id), &link);
+        if (result == EBPF_SUCCESS) {
+            // The NMR attach callback runs synchronously and inserts the client,
+            // so clients[attach_id] is guaranteed to exist here.
+            std::lock_guard<std::mutex> lock(_mutex);
+            clients[attach_id].link_object = link;
         }
+        return result;
+    }
 
-        ebpf_program_batch_begin_invoke_function_t batch_begin_function;
-        batch_begin_function = reinterpret_cast<decltype(batch_begin_function)>(client_dispatch_table->function[1]);
+    _Must_inspect_result_ ebpf_result_t
+    attach(_In_ const bpf_program* program, uint8_t attach_id)
+    {
+        bpf_link* link = nullptr;
+        ebpf_result_t result = ebpf_program_attach(program, &attach_type, &attach_id, sizeof(attach_id), &link);
+        if (result == EBPF_SUCCESS) {
+            std::lock_guard<std::mutex> lock(_mutex);
+            clients[attach_id].link_object = link;
+        }
+        return result;
+    }
 
+    _Must_inspect_result_ ebpf_result_t
+    attach(
+        _In_ const bpf_program* program,
+        _In_reads_bytes_(attach_parameters_size) void* attach_parameters,
+        size_t attach_parameters_size)
+    {
+        // Extract attach_id from raw params (same logic as NMR callback).
+        uint8_t attach_id = 0;
+        if (attach_parameters != nullptr && attach_parameters_size >= sizeof(uint8_t)) {
+            attach_id = *reinterpret_cast<const uint8_t*>(attach_parameters);
+        }
+        bpf_link* link = nullptr;
+        ebpf_result_t result =
+            ebpf_program_attach(program, &attach_type, attach_parameters, attach_parameters_size, &link);
+        if (result == EBPF_SUCCESS) {
+            std::lock_guard<std::mutex> lock(_mutex);
+            clients[attach_id].link_object = link;
+        }
+        return result;
+    }
+
+    void
+    detach(uint8_t attach_id)
+    {
+        bpf_link* link = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = clients.find(attach_id);
+            if (it != clients.end() && it->second.link_object != nullptr) {
+                link = it->second.link_object;
+                it->second.link_object = nullptr;
+            }
+        }
+        if (link != nullptr) {
+            ebpf_link_detach(link);
+            ebpf_link_close(link);
+        }
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    detach(fd_t program_fd, _In_reads_bytes_(attach_parameter_size) void* attach_parameter, size_t attach_parameter_size)
+    {
+        return ebpf_program_detach(program_fd, &attach_type, attach_parameter, attach_parameter_size);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    fire(_Inout_ void* context, _Out_ uint32_t* result, uint8_t attach_id)
+    {
+        ebpf_result_t (*invoke_program)(_In_ const void* link, _Inout_ void* context, _Out_ uint32_t* result) = nullptr;
+        const void* binding_context = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = clients.find(attach_id);
+            if (it == clients.end() || it->second.binding_context == nullptr) {
+                return EBPF_EXTENSION_FAILED_TO_LOAD;
+            }
+            auto* client = &it->second;
+            invoke_program = reinterpret_cast<decltype(invoke_program)>(client->dispatch_table->function[0]);
+            binding_context = client->binding_context;
+        }
+        return invoke_program(binding_context, context, result);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    batch_begin(size_t state_size, _Out_writes_(state_size) void* state, uint8_t attach_id)
+    {
+        ebpf_program_batch_begin_invoke_function_t batch_begin_function = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = clients.find(attach_id);
+            if (it == clients.end() || it->second.binding_context == nullptr) {
+                return EBPF_EXTENSION_FAILED_TO_LOAD;
+            }
+            batch_begin_function =
+                reinterpret_cast<decltype(batch_begin_function)>(it->second.dispatch_table->function[1]);
+        }
         return batch_begin_function(state_size, state);
     }
 
     _Must_inspect_result_ ebpf_result_t
-    batch_invoke(_Inout_ void* program_context, _Out_ uint32_t* result, _In_ const void* state)
+    batch_invoke(_Inout_ void* program_context, _Out_ uint32_t* result, _In_ const void* state, uint8_t attach_id)
     {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
+        ebpf_program_batch_invoke_function_t batch_invoke_function = nullptr;
+        const void* binding_context = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = clients.find(attach_id);
+            if (it == clients.end() || it->second.binding_context == nullptr) {
+                return EBPF_EXTENSION_FAILED_TO_LOAD;
+            }
+            auto* client = &it->second;
+            batch_invoke_function =
+                reinterpret_cast<decltype(batch_invoke_function)>(client->dispatch_table->function[2]);
+            binding_context = client->binding_context;
         }
-
-        ebpf_program_batch_invoke_function_t batch_invoke_function;
-        batch_invoke_function = reinterpret_cast<decltype(batch_invoke_function)>(client_dispatch_table->function[2]);
-        return batch_invoke_function(client_binding_context, program_context, result, state);
+        return batch_invoke_function(binding_context, program_context, result, state);
     }
 
     _Must_inspect_result_ ebpf_result_t
-    batch_end(_In_ void* state)
+    batch_end(_In_ void* state, uint8_t attach_id)
     {
-        if (client_binding_context == nullptr) {
-            return EBPF_EXTENSION_FAILED_TO_LOAD;
+        ebpf_program_batch_end_invoke_function_t batch_end_function = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto it = clients.find(attach_id);
+            if (it == clients.end() || it->second.binding_context == nullptr) {
+                return EBPF_EXTENSION_FAILED_TO_LOAD;
+            }
+            batch_end_function =
+                reinterpret_cast<decltype(batch_end_function)>(it->second.dispatch_table->function[3]);
         }
-
-        ebpf_program_batch_end_invoke_function_t batch_end_function;
-        batch_end_function = reinterpret_cast<decltype(batch_end_function)>(client_dispatch_table->function[3]);
         return batch_end_function(state);
     }
 
     _Ret_maybenull_ const ebpf_extension_data_t*
-    get_client_data() const
+    get_client_data(uint8_t attach_id) const
     {
-        return client_data;
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = clients.find(attach_id);
+        if (it == clients.end()) {
+            return nullptr;
+        }
+        return it->second.data;
     }
 
+  protected:
+    ebpf_attach_type_t attach_type;
+
+    struct client_entry_t
+    {
+        _hook_provider* owner = nullptr;
+        uint8_t id = 0;
+        PNPI_REGISTRATION_INSTANCE registration_instance = nullptr;
+        const void* binding_context = nullptr;
+        const ebpf_extension_data_t* data = nullptr;
+        const ebpf_extension_dispatch_table_t* dispatch_table = nullptr;
+        HANDLE nmr_binding_handle = nullptr;
+        bpf_link* link_object = nullptr;
+    };
+
+    std::map<uint8_t, client_entry_t> clients;
+
   private:
+
     static NTSTATUS
     provider_attach_client_callback(
         HANDLE nmr_binding_handle,
@@ -238,43 +321,52 @@ typedef class _single_instance_hook : public _hook_helper
         _Out_ void** provider_binding_context,
         _Outptr_result_maybenull_ const void** provider_dispatch)
     {
-        auto hook = reinterpret_cast<_single_instance_hook*>(provider_context);
+        auto hook = reinterpret_cast<_hook_provider*>(provider_context);
+        std::lock_guard<std::mutex> lock(hook->_mutex);
 
-        if (hook->client_binding_context != nullptr) {
-            // Can't attach a single-instance provider to a second client.
+        // Read attach_id from attach parameters. Default to 0 if absent.
+        uint8_t attach_id = 0;
+        auto client_data =
+            reinterpret_cast<const ebpf_extension_data_t*>(client_registration_instance->NpiSpecificCharacteristics);
+        if (client_data != nullptr && client_data->data != nullptr &&
+            client_data->data_size >= sizeof(uint8_t)) {
+            attach_id = *reinterpret_cast<const uint8_t*>(client_data->data);
+        }
+
+        // Reject if max_clients already reached or attach_id already in use.
+        if (hook->clients.size() >= hook->_max_clients) {
             return STATUS_NOINTERFACE;
         }
-        UNREFERENCED_PARAMETER(nmr_binding_handle);
-        hook->client_registration_instance = client_registration_instance;
-        hook->client_binding_context = client_binding_context;
-        hook->nmr_binding_handle = nmr_binding_handle;
-        hook->client_dispatch_table = (ebpf_extension_dispatch_table_t*)client_dispatch;
-        hook->client_data =
-            reinterpret_cast<const ebpf_extension_data_t*>(client_registration_instance->NpiSpecificCharacteristics);
-        *provider_binding_context = provider_context;
+        if (hook->clients.count(attach_id) != 0) {
+            return STATUS_NOINTERFACE;
+        }
+
+        auto& slot = hook->clients[attach_id];
+        slot.owner = hook;
+        slot.id = attach_id;
+        slot.registration_instance = client_registration_instance;
+        slot.binding_context = client_binding_context;
+        slot.nmr_binding_handle = nmr_binding_handle;
+        slot.dispatch_table = (const ebpf_extension_dispatch_table_t*)client_dispatch;
+        slot.data = client_data;
+
+        *provider_binding_context = &slot;
         *provider_dispatch = NULL;
         return STATUS_SUCCESS;
-    };
+    }
 
     static NTSTATUS
     provider_detach_client_callback(_Inout_ void* provider_binding_context)
     {
-        auto hook = reinterpret_cast<_single_instance_hook*>(provider_binding_context);
-        hook->client_binding_context = nullptr;
-        hook->client_data = nullptr;
-        hook->client_dispatch_table = nullptr;
-
-        // There should be no in-progress calls to any client functions,
-        // we we can return success rather than pending.
+        auto entry = reinterpret_cast<client_entry_t*>(provider_binding_context);
+        auto* hook = entry->owner;
+        std::lock_guard<std::mutex> lock(hook->_mutex);
+        hook->clients.erase(entry->id);
         return EBPF_SUCCESS;
-    };
-    ebpf_attach_type_t attach_type;
-    ebpf_attach_provider_data_t attach_provider_data;
+    }
 
-    NPI_MODULEID module_id = {
-        sizeof(NPI_MODULEID),
-        MIT_GUID,
-    };
+    ebpf_attach_provider_data_t attach_provider_data;
+    NPI_MODULEID module_id = {sizeof(NPI_MODULEID), MIT_GUID};
     const NPI_PROVIDER_CHARACTERISTICS provider_characteristics = {
         0,
         sizeof(provider_characteristics),
@@ -291,11 +383,81 @@ typedef class _single_instance_hook : public _hook_helper
         },
     };
     HANDLE nmr_provider_handle;
+    uint32_t _max_clients;
+    mutable std::mutex _mutex;
+} hook_provider_t;
 
-    PNPI_REGISTRATION_INSTANCE client_registration_instance = nullptr;
-    const void* client_binding_context = nullptr;
-    const ebpf_extension_data_t* client_data = nullptr;
-    const ebpf_extension_dispatch_table_t* client_dispatch_table = nullptr;
-    HANDLE nmr_binding_handle = nullptr;
-    bpf_link* link_object = nullptr;
+// For backward compatibility.
+typedef _hook_provider multi_instance_hook_t;
+
+/**
+ * @brief Single-instance hook provider. Constrains _hook_provider to max 1 client.
+ *        Provides convenience overloads that omit attach_id (always uses 0).
+ */
+typedef class _single_instance_hook : public _hook_provider
+{
+  public:
+    _single_instance_hook(
+        ebpf_program_type_t program_type,
+        ebpf_attach_type_t attach_type,
+        bpf_link_type link_type = BPF_LINK_TYPE_UNSPEC)
+        : _hook_provider{program_type, attach_type, link_type, 1}
+    {
+    }
+
+    using _hook_provider::attach;
+    using _hook_provider::detach;
+    using _hook_provider::fire;
+    using _hook_provider::batch_begin;
+    using _hook_provider::batch_invoke;
+    using _hook_provider::batch_end;
+    using _hook_provider::get_client_data;
+
+    _Must_inspect_result_ ebpf_result_t
+    attach(fd_t program_fd)
+    {
+        return _hook_provider::attach(program_fd, 0);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    attach(_In_ const bpf_program* program)
+    {
+        return _hook_provider::attach(program, (uint8_t)0);
+    }
+
+    void
+    detach()
+    {
+        _hook_provider::detach((uint8_t)0);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    fire(_Inout_ void* context, _Out_ uint32_t* result)
+    {
+        return _hook_provider::fire(context, result, 0);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    batch_begin(size_t state_size, _Out_writes_(state_size) void* state)
+    {
+        return _hook_provider::batch_begin(state_size, state, 0);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    batch_invoke(_Inout_ void* program_context, _Out_ uint32_t* result, _In_ const void* state)
+    {
+        return _hook_provider::batch_invoke(program_context, result, state, 0);
+    }
+
+    _Must_inspect_result_ ebpf_result_t
+    batch_end(_In_ void* state)
+    {
+        return _hook_provider::batch_end(state, 0);
+    }
+
+    _Ret_maybenull_ const ebpf_extension_data_t*
+    get_client_data() const
+    {
+        return _hook_provider::get_client_data(0);
+    }
 } single_instance_hook_t;


### PR DESCRIPTION
## Description
This is the first PR towards addressing #5387. This introduces an user mode test hook_provider class in hook_helper.h for a mock sample extension that supports multiple clients to be attached and invoked.

## Testing
A unit test variation is added to validate the test helper class.

If new tests were added:

- [x] Unit tests are added.
- [ ] Driver tests are added.
- [ ] Fuzz tests are added.

## Documentation
Is there any documentation impact for this change?
No.

## Installation
Is there any installer impact for this change?
No.